### PR TITLE
Implement smartphone-friendly signup and comment replies

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,13 @@
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
+    <div id="signup-overlay" class="overlay hidden">
+      <form id="signup-form" class="signup-form">
+        <label for="signup-name">Name:</label>
+        <input id="signup-name" type="text" required>
+        <button type="submit">Start</button>
+      </form>
+    </div>
     <header>
       <h1>NetUp</h1>
       <a href="#chat-feed" class="header-btn">Feed</a>

--- a/scripts.js
+++ b/scripts.js
@@ -2,12 +2,63 @@ const form = document.getElementById('chat-form');
 const textarea = form.querySelector('textarea[name="message"]');
 const feedList = document.getElementById('feed-list');
 
+const signupOverlay = document.getElementById('signup-overlay');
+const signupForm = document.getElementById('signup-form');
+const signupName = document.getElementById('signup-name');
+
+let username = localStorage.getItem('username');
+if (!username) {
+  signupOverlay.classList.remove('hidden');
+}
+
+signupForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  username = signupName.value.trim();
+  if (username) {
+    localStorage.setItem('username', username);
+    signupOverlay.classList.add('hidden');
+  }
+});
+
+function buildCommentElement(text, user) {
+  const li = document.createElement('li');
+  li.innerHTML = `<strong>${user}</strong><p>${text}</p><button class="reply-btn">Antworten</button>`;
+  const replies = document.createElement('ul');
+  li.appendChild(replies);
+  const replyForm = document.createElement('form');
+  replyForm.classList.add('reply-form', 'hidden');
+  replyForm.innerHTML = '<textarea></textarea><button type="submit">Senden</button>';
+  li.appendChild(replyForm);
+  return li;
+}
+
 form.addEventListener('submit', function (event) {
   event.preventDefault();
   const text = textarea.value.trim();
-  if (text === '') return;
-  const li = document.createElement('li');
-  li.textContent = text;
+  if (text === '' || !username) return;
+  const li = buildCommentElement(text, username);
   feedList.prepend(li);
   textarea.value = '';
+});
+
+feedList.addEventListener('click', (event) => {
+  if (event.target.classList.contains('reply-btn')) {
+    const li = event.target.closest('li');
+    const replyForm = li.querySelector('.reply-form');
+    replyForm.classList.toggle('hidden');
+  }
+});
+
+feedList.addEventListener('submit', (event) => {
+  if (event.target.classList.contains('reply-form')) {
+    event.preventDefault();
+    const textarea = event.target.querySelector('textarea');
+    const text = textarea.value.trim();
+    if (text === '' || !username) return;
+    const replies = event.target.parentElement.querySelector('ul');
+    const newLi = buildCommentElement(text, username);
+    replies.prepend(newLi);
+    textarea.value = '';
+    event.target.classList.add('hidden');
+  }
 });

--- a/style.css
+++ b/style.css
@@ -1,15 +1,41 @@
 
 
-      * {
-        box-sizing: border-box;
-      }
+
+* {
+  box-sizing: border-box;
+}
       
-      body {
-        font-family: Arial, sans-serif;
-        margin: 0;
-        padding: 0;
-        background-color: #f5f5f5;
-      }
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f5f5f5;
+}
+
+.hidden {
+  display: none;
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.signup-form {
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 10px;
+  display: flex;
+  gap: 10px;
+}
 
       header {
         background-color: #19c583;
@@ -49,20 +75,21 @@
       
       
 
-      main {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        height: 100vh;
-      }
+main {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  min-height: 100vh;
+  padding-top: 20px;
+}
 
-      form {
-        background-color: #E6ECF0;
-        border-radius: 10px;
-        padding: 20px;
-        text-align: center;
-        width: 500px;
-      }
+form {
+  background-color: #E6ECF0;
+  border-radius: 10px;
+  padding: 20px;
+  text-align: center;
+  width: 500px;
+}
 
       textarea {
         width: 100%;
@@ -95,14 +122,30 @@
         margin: 0 auto;
       }
 
-      li {
-        background-color: #E6ECF0;
-        border-radius: 10px;
-        margin-bottom: 20px;
-        padding: 20px;
-        width: 500px;
-        text-align: left;
-      }
+li {
+  background-color: #E6ECF0;
+  border-radius: 10px;
+  margin-bottom: 20px;
+  padding: 20px;
+  width: 500px;
+  text-align: left;
+}
+
+#chat-feed {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.reply-form textarea {
+  height: 60px;
+}
+
+@media (max-width: 600px) {
+  form,
+  li {
+    width: 90%;
+  }
+}
 
       footer {
         background-color: #19c583;


### PR DESCRIPTION
## Summary
- add simple signup overlay for username-only logins
- show new style rules for overlay and mobile responsiveness
- implement nested comments with reply forms in scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d176c5a883229fd3a7a7f1afe60d